### PR TITLE
Add hashbender as a contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,4 +3,5 @@
 The people who built Jardinero.
 
 - [@GuzmanPintos](https://github.com/GuzmanPintos)
+- [@hashbender](https://github.com/hashbender)
 - [@luciocorral](https://github.com/luciocorral)


### PR DESCRIPTION
This PR adds @hashbender to the Jardinero contributor list.