### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.changeset/pin-actions-to-sha.md
+++ b/.changeset/pin-actions-to-sha.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: pin GitHub Actions to commit SHAs

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,18 +27,18 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.CHANGESET_BOT_APP_ID }}
           private-key: ${{ secrets.CHANGESET_BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -104,7 +104,7 @@ jobs:
           gh pr merge --auto --squash "release/${RELEASE_TAG}"
 
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           name: ${{ env.RELEASE_TAG }}
           tag_name: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: tenki-standard-large-8c-16g
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Pinned via .nvmrc so local and CI use the same Node line.
           node-version-file: .nvmrc
@@ -39,6 +39,6 @@ jobs:
         run: echo "::notice::Changeset check skipped (release/renovate branch or [skip changeset] in title)."
 
       - if: env.SKIP != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - if: env.SKIP != 'true'
         run: make check-changeset

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: tenki-standard-large-8c-16g
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -22,10 +22,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -33,10 +33,10 @@ jobs:
       - run: make check CHECK_CHANGESET=false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,7 +58,7 @@ jobs:
           echo "NODE_VERSION=$(cat .nvmrc)-bookworm-slim" | tee -a "$GITHUB_ENV"
 
       - name: Build and push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile.prod


### PR DESCRIPTION
Every `uses:` now carries a 40-character commit SHA with the version in a trailing comment. Tags are mutable, including semver-looking ones, so a tag can be moved onto new code silently; a SHA only changes through an auditable diff. Six refs were unpinned (`actions/setup-node@v4` ×4, `actions/checkout@v4` ×2), and those checkout refs also lagged the v6.0.2 the other three workflows already used.

Actions move to current releases in the same pass: checkout v7.0.1, setup-node v7.0.0, create-github-app-token v3.2.0, action-gh-release v3.0.2, setup-buildx-action v4.3.0, login-action v4.6.0, build-push-action v7.3.0. pnpm/action-setup was already latest and pinned, so it is unchanged.

## Verify

setup-node crosses three majors. v5 switched the action to node24 and requires runner v2.327.1 or later — the Tenki runner version is not exposed through the API, so this PR's own `Check` job on `tenki-standard-large-8c-16g` is the test for it. v6 narrowed automatic caching to npm, which these workflows already cover with an explicit `cache: pnpm`. If `Check` fails on a runner-version error, revert setup-node to its v4 SHA and land the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
