### PR TITLE
ci: use a dedicated release App for the public repo

### DIFF
--- a/.changeset/public-releaser-app.md
+++ b/.changeset/public-releaser-app.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: use a dedicated release App for the public repo

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,10 +8,10 @@ name: Create release
 # Auth is a GitHub App rather than the default GITHUB_TOKEN, because a push made
 # with GITHUB_TOKEN does not trigger the downstream tag build. Credentials are
 # the RELEASER_CLIENT_ID and RELEASER_PRIVATE_KEY repo secrets, from an App
-# installed on this repository alone. Do not switch to the org-wide changesets
-# bot: an App private key can mint tokens for every repo that App is installed
-# on, so exposing it here would give this public repo write access to private
-# ones.
+# installed on this repository alone. Keep it that way: an App private key is
+# scoped to the App, not to an installation, so reusing an App that is also
+# installed on other repositories would extend this repository's write access
+# to every one of them.
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,8 +6,12 @@ name: Create release
 # build. There is no persistent "Version Packages" bot PR.
 #
 # Auth is a GitHub App rather than the default GITHUB_TOKEN, because a push made
-# with GITHUB_TOKEN does not trigger the downstream tag build. Provide its
-# credentials as the CHANGESET_BOT_APP_ID and CHANGESET_BOT_PRIVATE_KEY secrets.
+# with GITHUB_TOKEN does not trigger the downstream tag build. Credentials are
+# the RELEASER_CLIENT_ID and RELEASER_PRIVATE_KEY repo secrets, from an App
+# installed on this repository alone. Do not switch to the org-wide changesets
+# bot: an App private key can mint tokens for every repo that App is installed
+# on, so exposing it here would give this public repo write access to private
+# ones.
 
 on:
   workflow_dispatch: {}
@@ -29,8 +33,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.CHANGESET_BOT_APP_ID }}
-          private-key: ${{ secrets.CHANGESET_BOT_PRIVATE_KEY }}
+          client-id: ${{ secrets.RELEASER_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -65,7 +65,9 @@ graph TD
 
 ## One-time setup
 
-Releases authenticate as the **CHANGESET_BOT** GitHub App, via `actions/create-github-app-token`. This is what attributes the release PR and tag to a bot instead of a person, and what lets the tag trigger the downstream image build (the default `GITHUB_TOKEN` cannot). Before the first release:
+Releases authenticate as a GitHub App via `actions/create-github-app-token`, rather than the default `GITHUB_TOKEN`. This attributes the release PR and tag to a bot instead of a person, and lets the tag trigger the downstream image build — a push made with `GITHUB_TOKEN` does not. Before the first release:
 
-- Install the **CHANGESET_BOT** app on this repository with `contents` and `pull-requests` write.
-- Make sure the org secrets `CHANGESET_BOT_APP_ID` and `CHANGESET_BOT_PRIVATE_KEY` are visible to this repo (org-level, the way the `CI_GCP_*` secrets already are).
+- Create a GitHub App and install it **on this repository only**, granting `contents: write`, `pull requests: write`, and `metadata: read`.
+- Add its credentials as **repository** secrets: `RELEASER_CLIENT_ID` (the App's Client ID) and `RELEASER_PRIVATE_KEY` (the PEM you download when generating a signing key).
+
+Use an App dedicated to this repository rather than one shared with others. An App private key is scoped to the App, not to an installation: whatever holds the key can mint an installation token for every repository that App is installed on. Sharing one with a public repository therefore extends write access to all of them. Keeping the credentials in repository secrets rather than organization secrets leaves that boundary enforced by GitHub instead of by a visibility setting.


### PR DESCRIPTION
`create-release.yml` has been broken since the repo went public: it consumed `CHANGESET_BOT_APP_ID` / `CHANGESET_BOT_PRIVATE_KEY`, which are `private`-visibility org secrets and resolve empty on a public repo. It is `workflow_dispatch`-only, so it would have failed on the first release rather than in CI.

The fix is a dedicated App — `luxor-jardinero-releaser-public`, installed on this repository alone with `contents: write`, `pull_requests: write`, `metadata: read` — rather than adding this repo to the org changesets bot's installation list. A GitHub App private key is per-App, not per-installation: a holder can call `/app/installations` and mint a token for any installation of that App, so exposing the org bot's key to a public repo's CI would grant write access to every private repo it is installed on. Installing the same App twice is not possible either — one installation per App per org.

Credentials are `RELEASER_CLIENT_ID` and `RELEASER_PRIVATE_KEY`, stored as **repo-level** secrets. A repo secret cannot be read by another repository, so the blast radius is bounded by GitHub rather than by a visibility setting someone could widen later.

## Verify

CI does not exercise this workflow — it is `workflow_dispatch`-only, so the real test is the first dispatch. Expect the `Generate app token` step to succeed; a failure there means the secret values are wrong, not the wiring. Note `client-id:` takes the App's **Client ID** (`Iv23li…`), not the numeric App ID; `app-id:` is deprecated in create-github-app-token v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
