### PR TITLE
ci: grant artifact-metadata write on publish

### DIFF
--- a/.changeset/artifact-metadata-permission.md
+++ b/.changeset/artifact-metadata-permission.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: register artifact metadata storage records on publish

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -27,8 +27,11 @@ jobs:
       contents: read
       packages: write
       # OIDC token for keyless signing; attestations for the provenance record.
+      # artifact-metadata lets the attestation register a storage record, which
+      # is what lists the image on the organisation's linked artifacts page.
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
Every publish logs two warnings from the attestation step: that `artifact-metadata:write` may be missing, and that the storage record could not be created. This grants the permission.

The attestation itself is unaffected either way — the current unsigned-permission runs still produce a valid, verifiable attestation. What fails is the storage record beside it, which is what lists the image on the organisation's linked artifacts page. So this is inventory, not security.

The permission key was validated before touching this workflow: a throwaway push-triggered workflow carrying `artifact-metadata: write` parsed and ran successfully, so the key is recognised. That mattered because an unrecognised permission key fails workflow parsing, and this workflow only runs at publish time, where the failure would land mid-release.

## Verify

The next publish should log neither warning. If the second one persists, the cause is not the permission: the API matches "any artifact matching the provided digest and associated with a repository owned by the organization", and the package is already linked to this repository, so a remaining failure would point at indexing or feature availability rather than access.

Unrelated but worth recording: with SBOM and attestations attached, one publish now produces several package versions — currently 23 across 5 real tags, 2 `sha256-*` attestation manifests and 16 untagged index children. The signatures and attestations **are** those untagged and `sha256-*` manifests, so a "delete untagged versions" retention job would strip them. Worth knowing before any package cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
