### PR TITLE
ci: add a renovate configuration

### DIFF
--- a/.changeset/renovate-config.md
+++ b/.changeset/renovate-config.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: add a renovate configuration

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": true,
+  "extends": ["config:recommended"],
+  "schedule": ["every weekend"],
+  "labels": ["dependencies", "renovate"],
+  "configMigration": true,
+  "rebaseWhen": "conflicted",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["every weekend"]
+  },
+  "prConcurrentLimit": 5,
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": ["security"]
+  },
+  "packageRules": [
+    {
+      "description": "Manage github-actions SHA pins manually. Renovate opening a digest-bump PR runs CI with the new SHA — if upstream's tag has been hijacked, secrets are exfiltrated before we even review the PR. Same rationale as the other repositories; the pins here need a periodic manual sweep, because nothing will remind you.",
+      "matchManagers": ["github-actions"],
+      "enabled": false
+    },
+    {
+      "description": "Hold Node on major 24. .nvmrc is the single source for both CI and the published image's base tag (publish-image.yml derives NODE_VERSION from it), and Dockerfile.prod carries its own ARG default that has to move with it. A major bump is a deliberate change across all three, not a dependency PR. Widen this when you are ready to move.",
+      "matchPackageNames": ["node"],
+      "allowedVersions": "/^24(\\.|-|$)/"
+    },
+    {
+      "description": "Batch non-major devDependency updates into one PR.",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "devDependencies (non-major)"
+    },
+    {
+      "description": "Batch patch-level production dependency updates.",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "dependencies (patch)"
+    },
+    {
+      "groupName": "react",
+      "matchPackageNames": [
+        "/^react$/",
+        "/^react-dom$/",
+        "/^@types/react($|-)/",
+        "/^@vitejs/plugin-react$/"
+      ]
+    },
+    {
+      "groupName": "react UI ecosystem",
+      "matchPackageNames": [
+        "/^@radix-ui//",
+        "/^lucide-react$/",
+        "/^clsx$/",
+        "/^class-variance-authority$/",
+        "/^tailwind-merge$/"
+      ]
+    },
+    {
+      "groupName": "tailwind ecosystem",
+      "matchPackageNames": ["/^tailwindcss$/", "/^@tailwindcss//"]
+    },
+    {
+      "groupName": "typescript + node types",
+      "matchPackageNames": ["/^typescript$/", "/^tsx$/", "/^@types/node$/"]
+    },
+    {
+      "groupName": "changesets",
+      "matchPackageNames": ["/^@changesets//"]
+    }
+  ]
+}


### PR DESCRIPTION
Adapts the configuration the other repositories use to this stack. There are four production dependencies and a React dashboard here, so the Next.js, Prisma, auth and AWS SDK groups are dropped and the React, Radix, Tailwind and TypeScript ones are kept. `minimumReleaseAge: 14 days`, weekend schedule, `prConcurrentLimit: 5` and the OSV alerting all carry over unchanged.

Two rules encode reasoning that is not obvious from reading the file.

**The `github-actions` manager stays disabled**, matching the other repositories: a digest-bump PR runs CI with the new SHA before anyone reviews it, so a hijacked upstream tag reaches secrets ahead of review. The consequence for this repository specifically is that the eight action pins added recently will now drift, with nothing to remind anyone, so they need a periodic manual sweep.

**Node is held on major 24.** `.nvmrc` is the single source for both the CI Node version and the published image's base tag — `publish-image.yml` derives `NODE_VERSION` from it — while `Dockerfile.prod` carries its own `ARG NODE_VERSION=24-bookworm-slim` default that has to move with it. An unconstrained bump would move one and desync the others. Same shape as the postgres major rule elsewhere: widen the regex when the move is being made deliberately.

**Automerge is deliberately absent.** This repository requires one approval and `tenki-reviewer` satisfies that automatically, with auto-merge enabled at the repository level. Turning on Renovate automerge would therefore land dependency updates on `main` with no person involved. That may be a fine tradeoff, but it should be chosen rather than inherited.

Nothing here pins the base image digest; the floating tag is intentional, so each build picks up upstream patch releases.

## Verify

Renovate is installed on the organisation with `selection=selected`, so this repository may still need adding to that list before anything runs. First effect is a dependency dashboard issue plus the first batch of grouped PRs on the next weekend run. `pull-request.yml` already skips the changeset check for `renovate/` branches, so those PRs will not fail on a missing changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
