### PR TITLE
fix(test): assert through the optional chain instead of past it

### DIFF
--- a/.changeset/biome-unsafe-optional-chaining.md
+++ b/.changeset/biome-unsafe-optional-chaining.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: make three test assertions fail cleanly on a missing element

--- a/src/adapters/discord/discord-api.test.ts
+++ b/src/adapters/discord/discord-api.test.ts
@@ -229,7 +229,10 @@ describe('Discord thread names', () => {
         threadName: testCase.threadName,
       });
 
-      assert.equal((discord.calls[0]?.body as { name: string }).name, testCase.wantName);
+      assert.equal(
+        (discord.calls[0]?.body as { name: string } | undefined)?.name,
+        testCase.wantName,
+      );
     });
   }
 });

--- a/src/adapters/github/github-delivery.test.ts
+++ b/src/adapters/github/github-delivery.test.ts
@@ -224,7 +224,10 @@ describe('handleGitHubDelivery', () => {
         assert.equal(events.at(0)?.checksAreRed, c.want.checksAreRed);
       }
       if (c.want.headBranch !== undefined) {
-        assert.equal((events.at(0)?.ref as { headBranch?: string }).headBranch, c.want.headBranch);
+        assert.equal(
+          (events.at(0)?.ref as { headBranch?: string } | undefined)?.headBranch,
+          c.want.headBranch,
+        );
       }
     });
   }
@@ -529,7 +532,7 @@ describe('handleGitHubDelivery', () => {
         },
       });
 
-      assert.equal((events.at(0)?.ref as CommentData).reviewThreadId, testCase.want);
+      assert.equal((events.at(0)?.ref as CommentData | undefined)?.reviewThreadId, testCase.want);
     });
   }
 


### PR DESCRIPTION
Unblocks #21 (`@biomejs/biome` 2.4.16 → 2.5.8), which fails `Check` on three pre-existing sites the new version reports under `lint/correctness/noUnsafeOptionalChaining`.

The rule is right about all three. Each took an optional chain, cast the result to a non-optional type, then read a property off it:

```ts
(events.at(0)?.ref as CommentData).reviewThreadId
```

If the element is missing, the chain yields `undefined`, the cast asserts otherwise, and the read throws a `TypeError`. A test that should have failed on a comparison instead fails on a crash that names neither the expected nor the actual value.

Casting to `| undefined` and reading through `?.` makes the assertion compare `undefined` against what was expected, which is the failure these tests were written to produce. `github-delivery.test.ts` already uses exactly that shape a few hundred lines above one of the sites, so this makes the file consistent with itself.

## Why separate from #21

Renovate's branch carries only the version bump and its lockfile. These fixes are correct on their own, land independently of the bump, and unblock any later Biome bump that would hit the same rule. Once this merges, #21 rebases green with nothing added to it.

## Verify

`make check` passes on the current Biome 2.4.16: 2622 tests, 0 failures — so this is not coupled to the upgrade. Linting the tree with `pnpm dlx @biomejs/biome@2.5.8` reports no errors, which is the state #21 needs.

The remaining `Found 1 info` from 2.5.8 is its `biome migrate` configuration-schema suggestion. It predates this change, is informational rather than a warning, and does not fail `--error-on-warnings`; worth doing on its own at some point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
