### PR TITLE
fix(release): keep versioning this package under changesets v3

### DIFF
--- a/.changeset/changesets-private-packages.md
+++ b/.changeset/changesets-private-packages.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: keep versioning this package under changesets v3

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "restricted",
+  "privatePackages": { "version": true, "tag": false },
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []


### PR DESCRIPTION
Prerequisite for #24 (`@changesets/cli` 2.31.1 → 3.0.0). That PR is green because nothing in CI runs the release path: `check-changeset` is an `awk` script over `.changeset/*.md`, and the CLI's versioning is only exercised by `create-release.yml`, which is `workflow_dispatch`-only. The break would surface at the next release.

Changesets 3.0.0: *"Private packages are no longer versioned by default. Set `privatePackages` to `true` to opt into versioning and tagging them."* This package is `"private": true` with no such setting.

## What that does, measured

Run against a clone of `main` with `@changesets/cli@3.0.0` installed and a pending changeset:

```
current config          exit=0, "All files have been updated"
                        version 0.8.0 -> 0.8.0        (no bump)
                        CHANGELOG.md unchanged
                        D .changeset/biome-unsafe-optional-chaining.md
                        D .changeset/renovate-config.md

with privatePackages    exit=0
                        version 0.8.0 -> 0.8.1
                        changesets consumed, CHANGELOG.md gains "## 0.8.1"
```

It exits 0 and reports success while doing nothing, and the empty changesets are consumed and deleted regardless — so a release run discards the notes describing the release and produces no release. `create-release.yml` then reads the unchanged version and aborts at `Verify tag is new` on a tag that already exists, which is loud but names the wrong cause.

## The setting

`version: true` opts into bumping. `tag: false` because the workflow cuts `vX.Y.Z` itself through `action-gh-release` after reading the new version, so changesets should not also tag.

## Verify

`make check` passes: 2622 tests, 0 failures. The option is inert on 2.31.1, which versions private packages regardless, so this is safe to merge before #24 and #24 needs no changes once it rebases.

Two other 3.0.0 breaking changes were checked and do not apply: `changeset version` now exiting 1 with no pending changesets is already pre-empted by the `Require pending changesets` step, and the removed `prettier` config option was never set. Node `^22.11 || ^24 || >=26` and pnpm `>=10` are satisfied by 24 and 11.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
