### PR TITLE
ci: enforce the dependency cooldown in pnpm so lock file maintenance can complete

### DIFF
--- a/.changeset/pnpm-minimum-release-age.md
+++ b/.changeset/pnpm-minimum-release-age.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: enforce the dependency cooldown in pnpm so lock file maintenance can complete

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,12 @@
 # peer used only by the deprecated transformWithEsbuild.
 allowBuilds:
   esbuild: true
+
+# Renovate delegates lock file refreshes to pnpm, so the cooldown has to be enforced
+# here; Renovate's own minimumReleaseAge never sees the transitive versions pnpm picks.
+# Strict mode refuses an immature version instead of auto-collecting it into
+# minimumReleaseAgeExclude, and the prune drops an exclusion once no resolved version
+# still needs it.
+minimumReleaseAge: 20160 # 14 days, in minutes
+minimumReleaseAgeStrict: true
+minimumReleaseAgeExcludePrune: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,28 @@ allowBuilds:
 minimumReleaseAge: 20160 # 14 days, in minutes
 minimumReleaseAgeStrict: true
 minimumReleaseAgeExcludePrune: true
+
+# These versions were locked before the cooldown existed and cannot satisfy it retroactively;
+# @tenkicloud/sandbox and freestyle were pinned by hand, the rest came in transitively under
+# vite. Each entry pins the exact version it excuses, so a later release of the same package is
+# still gated, and the prune above drops the entry once nothing resolves to it.
+minimumReleaseAgeExclude:
+  - '@oxc-project/types@0.147.0'
+  - 'rolldown@1.2.6'
+  - '@rolldown/binding-android-arm-eabi@1.2.6'
+  - '@rolldown/binding-android-arm64@1.2.6'
+  - '@rolldown/binding-darwin-arm64@1.2.6'
+  - '@rolldown/binding-darwin-x64@1.2.6'
+  - '@rolldown/binding-freebsd-x64@1.2.6'
+  - '@rolldown/binding-linux-arm-gnueabihf@1.2.6'
+  - '@rolldown/binding-linux-arm64-gnu@1.2.6'
+  - '@rolldown/binding-linux-arm64-musl@1.2.6'
+  - '@rolldown/binding-linux-ppc64-gnu@1.2.6'
+  - '@rolldown/binding-linux-s390x-gnu@1.2.6'
+  - '@rolldown/binding-linux-x64-gnu@1.2.6'
+  - '@rolldown/binding-linux-x64-musl@1.2.6'
+  - '@rolldown/binding-openharmony-arm64@1.2.6'
+  - '@rolldown/binding-win32-arm64-msvc@1.2.6'
+  - '@rolldown/binding-win32-x64-msvc@1.2.6'
+  - '@tenkicloud/sandbox@1.0.2'
+  - 'freestyle@0.2.2'

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
   "rebaseWhen": "conflicted",
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["every weekend"]
+    "schedule": ["every weekend"],
+    "minimumReleaseAgeBehaviour": "timestamp-optional"
   },
   "prConcurrentLimit": 5,
   "minimumReleaseAge": "14 days",


### PR DESCRIPTION
This PR moves the dependency cooldown into pnpm, where it can actually cover the versions lock file maintenance picks, and unblocks the stability check on #36.

`minimumReleaseAge` in `renovate.json` never applied to lock file maintenance. Renovate deletes the lockfile and delegates resolution to pnpm, which had no cooldown of its own beyond the pnpm 11 default of one day, so the transitive versions in #36 were chosen with the 14 day policy ignored entirely. Eight of the eleven bumps in that PR are younger than 14 days and one is a single day old.

Renovate also builds its lock file maintenance upgrade with no `releaseTimestamp`, and since v42 the default `minimumReleaseAgeBehaviour: timestamp-required` reads a missing timestamp as "not old enough". The stability check then waits on a date that never arrives. Setting `timestamp-optional` on the `lockFileMaintenance` block alone clears that without weakening the global default, which still behaves correctly for direct dependencies where the timestamps exist.

`minimumReleaseAgeStrict: true` is load bearing: without it pnpm auto-collects immature versions into `minimumReleaseAgeExclude` and installs them anyway. `minimumReleaseAgeExcludePrune: true` drops an exclusion once no resolved version still needs it, so the entries `pnpm audit --fix` writes for advisories do not silently become permanent exemptions.

Worth knowing before merging: the cooldown applies to every install, not just Renovate's, so a genuinely urgent upgrade now needs a `minimumReleaseAgeExclude` entry. The diff on #36 should also shrink once this lands, since most of what it currently carries is under 14 days old.

Validated with `renovate-config-validator` (passes as repo config) and `pnpm config list` on pnpm 11.23.0, which reads back all three settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TG4ip7BFhGmYT5pkbYsRos

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG4ip7BFhGmYT5pkbYsRos)_