### PR TITLE
chore: drop the unused prom-client dependency

### DIFF
--- a/.changeset/remove-unused-prom-client.md
+++ b/.changeset/remove-unused-prom-client.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: drop the unused prom-client dependency

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@tenkicloud/sandbox": "1.0.2",
     "dotenv": "17.4.2",
     "freestyle": "0.2.2",
-    "prom-client": "15.1.3",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       freestyle:
         specifier: 0.2.2
         version: 0.2.2
-      prom-client:
-        specifier: 15.1.3
-        version: 15.1.3
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -437,10 +434,6 @@ packages:
   '@manypkg/tools@2.1.2':
     resolution: {integrity: sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==}
     engines: {node: '>=20.0.0'}
-
-  '@opentelemetry/api@1.9.1':
-    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
-    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.147.0':
     resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
@@ -1074,9 +1067,6 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
-  bintrees@1.0.2:
-    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
-
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
@@ -1369,11 +1359,6 @@ packages:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prom-client@15.1.3:
-    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
-    engines: {node: ^16 || ^18 || >=20}
-    deprecated: prom-client has been replaced by @prometheus-io/client
-
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
@@ -1458,9 +1443,6 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
-
-  tdigest@0.1.2:
-    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
@@ -1895,8 +1877,6 @@ snapshots:
       jju: 1.4.0
       tinyglobby: 0.2.17
       yaml: 2.9.0
-
-  '@opentelemetry/api@1.9.1': {}
 
   '@oxc-project/types@0.147.0': {}
 
@@ -2345,8 +2325,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  bintrees@1.0.2: {}
-
   cac@7.0.0: {}
 
   class-variance-authority@0.7.1:
@@ -2584,11 +2562,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prom-client@15.1.3:
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      tdigest: 0.1.2
-
   react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -2671,10 +2644,6 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
-
-  tdigest@0.1.2:
-    dependencies:
-      bintrees: 1.0.2
 
   tinyexec@1.3.0: {}
 


### PR DESCRIPTION
## What

Removes `prom-client` from `dependencies`. It has been declared since the initial commit (`49ff4a8`) and is imported nowhere — no `prom-client` import, no `collectDefaultMetrics`, no `/metrics` endpoint anywhere in the 422 tracked files. Dropping it also removes `@opentelemetry/api`, `tdigest` and `bintrees` from the production image.

## Why

The Renovate dependency dashboard (#13) flags `prom-client` as deprecated with "Replacement PR? Unavailable", which reads as a dead end. It isn't: the npm deprecation message names the successor — the project was donated to the Prometheus org, lives at [prometheus/client_js](https://github.com/prometheus/client_js), and publishes as `@prometheus-io/client` (0.16.1). Since nothing here uses it, deleting is the right answer rather than migrating.

If a future change needs Prometheus metrics in this repo, add `@prometheus-io/client`, not `prom-client`.

## Verify

`make install` succeeds against the regenerated lockfile (frozen), and `make check` is green — type-check, format, lint, web build, and 2655 tests, 0 failures.
