### PR TITLE
ci: leave the lock file maintenance cooldown to pnpm

### DIFF
--- a/.changeset/lockfile-maintenance-age-gate.md
+++ b/.changeset/lockfile-maintenance-age-gate.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: leave the lock file maintenance cooldown to pnpm

--- a/renovate.json
+++ b/renovate.json
@@ -7,9 +7,10 @@
   "configMigration": true,
   "rebaseWhen": "conflicted",
   "lockFileMaintenance": {
+    "description": "No Renovate age gate here: pnpm enforces the cooldown for lock file refreshes, and it is the only side that sees the transitive versions pnpm picks. Gating here only warned when a release carried no timestamp.",
     "enabled": true,
     "schedule": ["every weekend"],
-    "minimumReleaseAgeBehaviour": "timestamp-optional"
+    "minimumReleaseAge": null
   },
   "prConcurrentLimit": 5,
   "minimumReleaseAge": "14 days",


### PR DESCRIPTION
## What

In `renovate.json`, the `lockFileMaintenance` block trades `"minimumReleaseAgeBehaviour": "timestamp-optional"` for `"minimumReleaseAge": null`, with a `description` recording why.

## Why

The dependency dashboard (#13) carries a standing entry under **Repository Problems**: `WARN: Some upgrade(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding.` Nothing is broken — Renovate logs that WARN every time the opt-out lets a release through without a timestamp, and WARN-level messages surface on the dashboard whether or not they are actionable. Missing timestamps are the registry's business, not ours, so the warning is permanent noise on a repo that otherwise reads clean.

`timestamp-optional` was set only inside `lockFileMaintenance` (default elsewhere is `timestamp-required`, and `config:recommended` does not touch the option), so that block is the sole source. The check it was relaxing is redundant: `pnpm-workspace.yaml` already enforces a 14-day cooldown with `minimumReleaseAge: 20160` and `minimumReleaseAgeStrict: true`, and as #37 established, pnpm is the only side that sees the transitive versions it picks. Removing the age constraint for this context removes the condition that triggers the warning rather than relaxing it — `minimumReleaseAgeBehaviour` only applies in conjunction with `minimumReleaseAge`.

Trade-off worth naming: today `timestamp-optional` still enforces 14 days on lock-file-maintenance updates that *do* carry a timestamp; `null` drops the check for all of them, leaving pnpm as the only gate for this one job. The top-level `"minimumReleaseAge": "14 days"` is untouched and still applies to every other update.

## Verify

`renovate-config-validator` passes on the new config, and reports two Configuration Errors when run against a deliberately broken copy, so the pass is meaningful. `make check` is green — type-check, format, lint, web build, 2655 tests, 0 failures.

The warning itself can only be confirmed gone on the next Renovate run; tick the "run again" checkbox at the bottom of #13 after merge to force one.
