### PR TITLE
worker: wait for Daytona's exit status and share the provider helpers

### DIFF
--- a/.changeset/daytona-exit-status.md
+++ b/.changeset/daytona-exit-status.md
@@ -1,0 +1,5 @@
+---
+"jardinero": patch
+---
+
+worker: wait for a Daytona session command's exit status instead of reading an unrecorded one as a failure

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -172,6 +172,8 @@ Recipes live in [`../tenki-images/`](../tenki-images/), with three worked exampl
 pnpm run smoke:tenki
 ```
 
+It creates a real sandbox on your image, writes and reads a file, runs a command, forwards your Codex auth and asks the model for a short answer. If that passes, the expensive half of the setup is done.
+
 ### Building it on Freestyle
 
 Choose the recipe exactly as above, then render its shared base plus repository toolchain into one setup script. `--no-verify` prevents the Tenki build driver's canary body from being appended; you will verify the resulting snapshot on Freestyle instead.
@@ -224,8 +226,6 @@ worker:
 ```
 
 **Check it.** Create a sandbox from the snapshot, run the recipe's `*.verify.sh` from a fresh clone inside it, then delete it. With Jardinero running, `/setup` must report `daytona_sdk`, `daytona_auth` and `codex_auth` as `ok` before the first paid run.
-
-It creates a real sandbox on your image, writes and reads a file, runs a command, forwards your Codex auth and asks the model for a short answer. If that passes, the expensive half of the setup is done.
 
 ## 5. Put it behind a public URL
 

--- a/src/orchestrator/worker/daytona-worker.test.ts
+++ b/src/orchestrator/worker/daytona-worker.test.ts
@@ -6,19 +6,22 @@ import { DaytonaProcessExecutionTimeoutError, type Sandbox } from '@daytona/sdk'
 import { loadConfig, type AppConfig } from '../../config.js';
 import type { SandboxRun } from '../../store/types.js';
 import type { SandboxRunContext } from '../sandbox-pool.js';
+import { captureLogs } from '../../testing/logger.js';
 import {
   DaytonaSandboxProvider,
   DaytonaWorkerRunner,
   daytonaSandboxCreateParams,
   daytonaSandboxName,
-  renderShellEnvironment,
+  unusedResourceOverrides,
 } from './daytona-worker.js';
 
 describe('DaytonaWorkerRunner', () => {
   test('When it is constructed without credentials then should defer authentication until a run', () => {
     assert.doesNotThrow(() => new DaytonaWorkerRunner(daytonaConfig(), {}));
   });
+});
 
+describe('DaytonaWorkerRunner.run', () => {
   test('When a run finishes then should drive it on a Daytona sandbox and delete it', async () => {
     const fake = fakeSandbox({ streamedStdout: '{"type":"turn.completed"}\n' });
     const config = daytonaConfig();
@@ -117,6 +120,18 @@ describe('DaytonaSandboxProvider.create', () => {
       assert.equal(fake.deleteCalls, testCase.wantDeletes);
     });
   }
+
+  test('When a repo sized its sandbox then should warn that the size is not used', async () => {
+    const config = daytonaConfig();
+    config.worker.repos = { 'acme/repo': { resources: { cpuCores: 8, memoryMb: 16384 } } };
+    const provider = providerWith(fakeSandbox(), () => undefined, config);
+    const logs = captureLogs(provider, 'log');
+
+    await provider.create({}, new AbortController().signal);
+
+    assert.equal(logs.at(0)?.level, 'warn');
+    assert.deepEqual(logs.at(0)?.fields, { configured: ['acme/repo'] });
+  });
 
   test('When the configured credential is absent then should reject before calling the API', async () => {
     const provider = new DaytonaSandboxProvider(daytonaConfig(), {});
@@ -272,12 +287,22 @@ describe('DaytonaSession.exec', () => {
       wantDeletedSessions: 1,
     },
     {
-      name: 'When the command completes with no exit code then should read it as a failure',
+      // The stream closes on any socket close, so an exit status that is not
+      // recorded yet must be waited for, never read as a failure.
+      name: 'When the exit code lands after the stream closes then should wait for it',
+      sandbox: { sessionExitCode: 7, pollsBeforeExitCode: 2 },
+      command: 'long-command',
+      stream: true,
+      wantExitCode: 7,
+      wantStdout: '',
+      wantDeletedSessions: 1,
+    },
+    {
+      name: 'When no exit code is ever recorded then should return error',
       sandbox: { sessionExitCode: null },
       command: 'long-command',
       stream: true,
-      wantExitCode: 1,
-      wantStdout: '',
+      wantError: /never reported an exit status/,
       wantDeletedSessions: 1,
     },
     {
@@ -500,15 +525,6 @@ describe('daytonaSandboxName', () => {
   });
 });
 
-describe('renderShellEnvironment', () => {
-  test('When values contain shell syntax and a name is invalid then should quote values and omit the name', () => {
-    assert.equal(
-      renderShellEnvironment({ SAFE_NAME: "one'two", 'NOT-SAFE': 'value' }),
-      "export SAFE_NAME='one'\\''two'\n",
-    );
-  });
-});
-
 interface FakeSandbox extends Sandbox {
   execCommands: string[];
   sessionCommands: string[];
@@ -518,9 +534,13 @@ interface FakeSandbox extends Sandbox {
   deleteCalls: number;
 }
 
-function providerWith(fake: FakeSandbox, onCreate: () => void = () => undefined) {
+function providerWith(
+  fake: FakeSandbox,
+  onCreate: () => void = () => undefined,
+  config: AppConfig = daytonaConfig(),
+) {
   return new DaytonaSandboxProvider(
-    daytonaConfig(),
+    config,
     { DAYTONA_API_KEY: 'key' },
     {
       createClient: () => ({
@@ -543,6 +563,8 @@ interface FakeSandboxOptions {
   streamedStderr?: string;
   // null is how a command that never reported an exit code reads back.
   sessionExitCode?: number | null;
+  // Reads that answer with no exit status before the recorded one appears.
+  pollsBeforeExitCode?: number;
   missingCommandId?: boolean;
   logsError?: Error;
   holdLogsOpen?: boolean;
@@ -554,6 +576,7 @@ function fakeSandbox(options: FakeSandboxOptions = {}): FakeSandbox {
   const sessionCommands: string[] = [];
   const createdSessions: string[] = [];
   const deletedSessions: string[] = [];
+  let exitCodeReads = 0;
   let deleteCalls = 0;
   const sandbox = {
     id: 'sandbox-1',
@@ -609,9 +632,11 @@ function fakeSandbox(options: FakeSandboxOptions = {}): FakeSandbox {
         if (options.streamedStdout) onStdout(options.streamedStdout);
         if (options.streamedStderr) onStderr(options.streamedStderr);
       },
-      getSessionCommand: async () => ({
-        exitCode: options.sessionExitCode === undefined ? 0 : options.sessionExitCode,
-      }),
+      getSessionCommand: async () => {
+        exitCodeReads += 1;
+        if (exitCodeReads <= (options.pollsBeforeExitCode ?? 0)) return { exitCode: null };
+        return { exitCode: options.sessionExitCode === undefined ? 0 : options.sessionExitCode };
+      },
       deleteSession: async (sessionId: string) => {
         deletedSessions.push(sessionId);
       },
@@ -633,6 +658,62 @@ function applyRootMove(command: string, files: Map<string, Uint8Array>): void {
   files.delete(move[1]!);
   files.set(move[2]!, content);
 }
+
+describe('unusedResourceOverrides', () => {
+  const cases: Array<{
+    name: string;
+    configure(config: AppConfig): void;
+    want: string[];
+  }> = [
+    {
+      name: 'When nothing is sized then should name nothing',
+      configure: () => undefined,
+      want: [],
+    },
+    {
+      name: 'When a repo is sized then should name that repo',
+      configure: (config) => {
+        config.worker.repos = { 'acme/repo': { resources: { cpuCores: 8, memoryMb: 16384 } } };
+      },
+      want: ['acme/repo'],
+    },
+    {
+      name: 'When only the default is sized then should name the default',
+      configure: (config) => {
+        config.worker.default.resources = { cpuCores: 8, memoryMb: 16384 };
+      },
+      want: ['default'],
+    },
+    {
+      name: 'When both are sized then should name the default first',
+      configure: (config) => {
+        config.worker.default.resources = { cpuCores: 8, memoryMb: 16384 };
+        config.worker.repos = { 'acme/repo': { resources: { cpuCores: 4, memoryMb: 8192 } } };
+      },
+      want: ['default', 'acme/repo'],
+    },
+    {
+      // A repo entry without resources takes the size it is given, so it is not
+      // something the operator asked for in vain.
+      name: 'When a repo is mapped without a size then should name nothing',
+      configure: (config) => {
+        config.worker.repos = { 'acme/repo': { image: 'snapshot-2' } };
+      },
+      want: [],
+    },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      const config = daytonaConfig();
+      config.worker.default.resources = undefined;
+      config.worker.repos = {};
+      testCase.configure(config);
+
+      assert.deepEqual(unusedResourceOverrides(config), testCase.want);
+    });
+  }
+});
 
 function daytonaConfig(): AppConfig {
   const config = loadConfig();

--- a/src/orchestrator/worker/daytona-worker.ts
+++ b/src/orchestrator/worker/daytona-worker.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
 
 import {
   Daytona,
@@ -8,7 +9,23 @@ import {
 } from '@daytona/sdk';
 
 import type { AppConfig } from '../../config.js';
-import { assertExecSucceeded, normalizeRemotePath, shellQuote } from './sandbox-utils.js';
+import { logger } from '../../platform/logger.js';
+import {
+  assertExecSucceeded,
+  buildGitCloneCommand,
+  concatBytes,
+  normalizeRemotePath,
+  numberOption,
+  renderShellEnvironment,
+  shellQuote,
+  streamToBytes,
+  stringOption,
+  stringRecord,
+  throwIfAborted,
+  WORKER_HOME,
+  WORKER_USER,
+  workerEnvironment,
+} from './sandbox-utils.js';
 import type {
   SandboxExecOutput,
   SandboxExecResult,
@@ -18,12 +35,6 @@ import type {
 import { SandboxWorkerRunner, type SandboxWorkerRunnerDeps } from './sandbox-worker.js';
 
 type SandboxWriteStreamOptions = NonNullable<Parameters<SandboxSession['fs']['writeStream']>[2]>;
-
-// The agent user the prepared worker images ship, and where Codex auth is
-// forwarded to; every provider lands on the same layout so one image recipe
-// serves each.
-const WORKER_USER = 'tenki';
-const WORKER_HOME = '/home/tenki';
 
 // The run's environment (tokens included) is sourced from this file because the
 // sudo hop to the worker user strips inherited variables, and inlining them in
@@ -37,6 +48,11 @@ const EXEC_TIMEOUT_SECONDS = 300;
 // Creation waits for the runner to pull the worker snapshot, which can far
 // outlast the SDK's 60s default on a cold pull.
 const CREATE_TIMEOUT_SECONDS = 600;
+
+// How many times the exit status is re-read and how long between reads; together
+// they are the budget that has to outlast the daemon's recording gap.
+const EXIT_CODE_ATTEMPTS = 8;
+const EXIT_CODE_POLL_MS = 250;
 
 // Command results the session consumes, structural because the SDK does not
 // re-export its ExecuteResponse type from the package root.
@@ -59,10 +75,20 @@ export class DaytonaWorkerRunner extends SandboxWorkerRunner {
   }
 }
 
+// unusedResourceOverrides names what an operator sized in vain: a Daytona sandbox
+// takes its CPU and memory from the snapshot, so the config's never reach it.
+export function unusedResourceOverrides(config: AppConfig): string[] {
+  const repos = Object.entries(config.worker.repos)
+    .filter(([, target]) => target.resources !== undefined)
+    .map(([repo]) => repo);
+  return config.worker.default.resources === undefined ? repos : ['default', ...repos];
+}
+
 export class DaytonaSandboxProvider implements SandboxProvider {
   readonly name = 'Daytona';
   readonly apiTarget: string;
   private readonly createClient: () => DaytonaClient;
+  private readonly log = logger.child('worker');
 
   constructor(
     private readonly config: AppConfig,
@@ -84,6 +110,10 @@ export class DaytonaSandboxProvider implements SandboxProvider {
 
   async create(options: Record<string, unknown>, signal: AbortSignal): Promise<SandboxSession> {
     throwIfAborted(signal);
+    const configured = unusedResourceOverrides(this.config);
+    if (configured.length > 0) {
+      this.log.warn('worker.resources does not apply on the Daytona runner', { configured });
+    }
     const client = this.createClient();
     const params = daytonaSandboxCreateParams(options);
     const sandbox = await client.create(params, { timeout: CREATE_TIMEOUT_SECONDS });
@@ -143,11 +173,7 @@ export class DaytonaSession implements SandboxSession {
   readonly git = {
     clone: async (url: string, options: { directory?: string } = {}) => {
       const directory = options.directory ?? `${WORKER_HOME}/workspace/repo`;
-      const credentialHelper =
-        '!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f';
-      const result = await this.execStreaming(
-        `git -c credential.helper=${shellQuote(credentialHelper)} clone ${shellQuote(url)} ${shellQuote(directory)}`,
-      );
+      const result = await this.execStreaming(buildGitCloneCommand(url, directory));
       assertExecSucceeded(result, 'clone repository');
     },
   };
@@ -257,9 +283,8 @@ export class DaytonaSession implements SandboxSession {
       await Promise.race([logs, aborted]);
       onOutput?.({ data: new Uint8Array(), isStderr: false, isFinal: true });
 
-      const completed = await process.getSessionCommand(sessionId, commandId);
       return {
-        exitCode: completed.exitCode ?? 1,
+        exitCode: await this.awaitExitCode(sessionId, commandId),
         stdout: concatBytes(stdout),
         stderr: concatBytes(stderr),
       };
@@ -267,6 +292,24 @@ export class DaytonaSession implements SandboxSession {
       if (abortHandler) this.signal.removeEventListener('abort', abortHandler);
       await process.deleteSession(sessionId).catch(() => undefined);
     }
+  }
+
+  // awaitExitCode waits for the status Daytona records once the command ends; the
+  // log stream closes on any socket close, so it can still be absent here, and
+  // reading that as a failure would discard a finished Codex run.
+  private async awaitExitCode(sessionId: string, commandId: string): Promise<number> {
+    const process = this.sandbox.process;
+    for (let attempt = 0; attempt < EXIT_CODE_ATTEMPTS; attempt += 1) {
+      throwIfAborted(this.signal);
+      const completed = await process.getSessionCommand(sessionId, commandId);
+      if (typeof completed.exitCode === 'number') return completed.exitCode;
+      await delay(EXIT_CODE_POLL_MS);
+    }
+    throw new Error(
+      `Daytona never reported an exit status for the session command after ${
+        (EXIT_CODE_ATTEMPTS * EXIT_CODE_POLL_MS) / 1_000
+      }s.`,
+    );
   }
 }
 
@@ -325,13 +368,6 @@ export function daytonaSandboxName(value: string): string {
     .slice(0, 63)
     .replace(/-$/g, '');
   return normalized || `jardinero-${randomUUID().slice(0, 8)}`;
-}
-
-export function renderShellEnvironment(env: Record<string, string>): string {
-  return `${Object.entries(env)
-    .filter(([name]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(name))
-    .map(([name, value]) => `export ${name}=${shellQuote(value)}`)
-    .join('\n')}\n`;
 }
 
 function daytonaApiTarget(apiUrl: string | undefined): string {
@@ -407,21 +443,6 @@ function assertDaytonaExecSucceeded(response: DaytonaExecResponse, label: string
   );
 }
 
-async function streamToBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  try {
-    for (;;) {
-      const next = await reader.read();
-      if (next.done) break;
-      chunks.push(next.value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return concatBytes(chunks);
-}
-
 function bytesToReadableStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
     start(controller) {
@@ -429,16 +450,6 @@ function bytesToReadableStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
       controller.close();
     },
   });
-}
-
-function concatBytes(chunks: Uint8Array[]): Uint8Array {
-  const result = new Uint8Array(chunks.reduce((total, chunk) => total + chunk.byteLength, 0));
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return result;
 }
 
 function toBuffer(content: string | Uint8Array): Buffer {
@@ -451,35 +462,4 @@ function sanitizeLabels(labels: Record<string, string>): Record<string, string> 
       .slice(0, 64)
       .map(([key, value]) => [key.slice(0, 63), value.slice(0, 63)]),
   );
-}
-
-function stringRecord(value: unknown): Record<string, string> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return {};
-  return Object.fromEntries(
-    Object.entries(value).filter(
-      (entry): entry is [string, string] => typeof entry[1] === 'string',
-    ),
-  );
-}
-
-function stringOption(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
-}
-
-function numberOption(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
-
-function workerEnvironment(env: Record<string, string>): Record<string, string> {
-  return {
-    ...env,
-    HOME: WORKER_HOME,
-    USER: WORKER_USER,
-    LOGNAME: WORKER_USER,
-    PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-  };
-}
-
-function throwIfAborted(signal: AbortSignal): void {
-  if (signal.aborted) throw new Error('Run aborted.');
 }

--- a/src/orchestrator/worker/freestyle-worker.test.ts
+++ b/src/orchestrator/worker/freestyle-worker.test.ts
@@ -11,7 +11,6 @@ import {
   FreestyleWorkerRunner,
   freestyleSlug,
   freestyleVmCreateOptions,
-  renderShellEnvironment,
 } from './freestyle-worker.js';
 
 describe('FreestyleWorkerRunner', () => {
@@ -52,6 +51,7 @@ describe('FreestyleSandboxProvider.create', () => {
     aborted?: boolean;
     abortAfterCreate?: boolean;
     resizeError?: Error;
+    rootExecStatusCode?: number;
     wantCreateCalls: number;
     wantResize?: Record<string, number>;
     wantDeletes: number;
@@ -98,11 +98,27 @@ describe('FreestyleSandboxProvider.create', () => {
       wantDeletes: 1,
       wantError: /Run aborted/,
     },
+    {
+      // A snapshot the worker user cannot be prepared on is unusable, so the VM
+      // goes away instead of running the agent on a broken box.
+      name: 'When the worker user cannot be prepared then should delete the VM',
+      options: {},
+      rootExecStatusCode: 1,
+      wantCreateCalls: 1,
+      wantDeletes: 1,
+      wantError: /prepare Freestyle worker user failed with exit code 1/,
+    },
   ];
 
   for (const testCase of cases) {
     test(testCase.name, async () => {
-      const fake = fakeVm({ resources: testCase.resources, resizeError: testCase.resizeError });
+      const fake = fakeVm({
+        resources: testCase.resources,
+        resizeError: testCase.resizeError,
+        ...(testCase.rootExecStatusCode === undefined
+          ? {}
+          : { rootExecStatusCode: testCase.rootExecStatusCode }),
+      });
       let createCalls = 0;
       const controller = new AbortController();
       const provider = providerWith(fake, () => {
@@ -290,6 +306,17 @@ describe('FreestyleSession.exec', () => {
       wantPtySignals: ['sigkill'],
       wantPtyCloses: 1,
     },
+    {
+      // Deleting the VM is what really stops the command, so a socket that is
+      // already gone must not turn the abort into an unhandled failure.
+      name: 'When the kill fails on an abort then should still abort the run',
+      vm: { holdPtyOpen: true, ptySignalError: new Error('socket closed') },
+      command: 'long-command',
+      stream: true,
+      abortWhileRunning: true,
+      wantError: /Run aborted/,
+      wantPtyCloses: 1,
+    },
   ];
 
   for (const testCase of cases) {
@@ -472,15 +499,6 @@ describe('freestyleSlug', () => {
   });
 });
 
-describe('renderShellEnvironment', () => {
-  test('When values contain shell syntax and a name is invalid then should quote values and omit the name', () => {
-    assert.equal(
-      renderShellEnvironment({ SAFE_NAME: "one'two", 'NOT-SAFE': 'value' }),
-      "export SAFE_NAME='one'\\''two'\n",
-    );
-  });
-});
-
 interface FakeVm extends Vm {
   resizeCalls: Array<Record<string, number>>;
   deleteCalls: number;
@@ -518,6 +536,9 @@ interface FakeVmOptions {
   resizeError?: Error;
   // null is how the provider reports a command its timeout killed.
   execStatusCode?: number | null;
+  // The root-level prepare and chown commands, which run before any session exec.
+  rootExecStatusCode?: number;
+  ptySignalError?: Error;
   streamedStdout?: string;
   streamedStderr?: string;
   ptyExitCode?: number;
@@ -611,6 +632,7 @@ function fakeVm(options: FakeVmOptions = {}): FakeVm {
           return {
             sessionId: 7,
             signal: (signal: string) => {
+              if (options.ptySignalError) throw options.ptySignalError;
               ptySignals.push(signal);
             },
           };
@@ -627,8 +649,12 @@ function fakeVm(options: FakeVmOptions = {}): FakeVm {
       // Only the session's own exec names a linuxUser; the root-level prepare and
       // chown commands have to keep succeeding whatever the case scripts.
       const isSessionExec = typeof request !== 'string' && request.linuxUser !== undefined;
-      const statusCode =
-        isSessionExec && options.execStatusCode !== undefined ? options.execStatusCode : 0;
+      // A null status is a real value here; the provider uses it for a timeout.
+      const statusCode = isSessionExec
+        ? options.execStatusCode === undefined
+          ? 0
+          : options.execStatusCode
+        : (options.rootExecStatusCode ?? 0);
       return { stdout: '', stderr: '', statusCode };
     },
   } as unknown as FakeVm;

--- a/src/orchestrator/worker/freestyle-worker.ts
+++ b/src/orchestrator/worker/freestyle-worker.ts
@@ -9,7 +9,22 @@ import {
 } from 'freestyle';
 
 import type { AppConfig } from '../../config.js';
-import { assertExecSucceeded, normalizeRemotePath, shellQuote } from './sandbox-utils.js';
+import {
+  assertExecSucceeded,
+  buildGitCloneCommand,
+  concatBytes,
+  normalizeRemotePath,
+  numberOption,
+  renderShellEnvironment,
+  shellQuote,
+  streamToBytes,
+  stringOption,
+  stringRecord,
+  throwIfAborted,
+  WORKER_HOME,
+  WORKER_USER,
+  workerEnvironment,
+} from './sandbox-utils.js';
 import type {
   SandboxExecOutput,
   SandboxExecResult,
@@ -19,11 +34,6 @@ import type {
 import { SandboxWorkerRunner, type SandboxWorkerRunnerDeps } from './sandbox-worker.js';
 
 type SandboxWriteStreamOptions = NonNullable<Parameters<SandboxSession['fs']['writeStream']>[2]>;
-
-// The agent user the prepared worker images ship, and where Codex auth is
-// forwarded to; both providers land on the same layout so one image serves each.
-const WORKER_USER = 'tenki';
-const WORKER_HOME = '/home/tenki';
 
 // The provider caps a one-shot exec at five minutes, which is why anything that
 // can outlast it goes through the PTY instead.
@@ -133,11 +143,7 @@ export class FreestyleSession implements SandboxSession {
   readonly git = {
     clone: async (url: string, options: { directory?: string } = {}) => {
       const directory = options.directory ?? `${WORKER_HOME}/workspace/repo`;
-      const credentialHelper =
-        '!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f';
-      const result = await this.execLong(
-        `git -c credential.helper=${shellQuote(credentialHelper)} clone ${shellQuote(url)} ${shellQuote(directory)}`,
-      );
+      const result = await this.execLong(buildGitCloneCommand(url, directory));
       assertExecSucceeded(result, 'clone repository');
     },
   };
@@ -324,13 +330,6 @@ export function freestyleSlug(value: string): string {
   return normalized || `jardinero-${randomUUID().slice(0, 8)}`;
 }
 
-export function renderShellEnvironment(env: Record<string, string>): string {
-  return `${Object.entries(env)
-    .filter(([name]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(name))
-    .map(([name, value]) => `export ${name}=${shellQuote(value)}`)
-    .join('\n')}\n`;
-}
-
 function freestyleApiTarget(baseUrl: string | undefined): string {
   if (!baseUrl) return 'beta-api.freestyle.sh';
   try {
@@ -382,68 +381,12 @@ function assertFreestyleExecSucceeded(result: ExecResult, label: string): void {
   );
 }
 
-async function streamToBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  try {
-    for (;;) {
-      const next = await reader.read();
-      if (next.done) break;
-      chunks.push(next.value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return concatBytes(chunks);
-}
-
-function concatBytes(chunks: Uint8Array[]): Uint8Array {
-  const result = new Uint8Array(chunks.reduce((total, chunk) => total + chunk.byteLength, 0));
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return result;
-}
-
 function sanitizeMetadata(metadata: Record<string, string>): Record<string, string> {
   return Object.fromEntries(
     Object.entries(metadata)
       .slice(0, 64)
       .map(([key, value]) => [key.slice(0, 63), value.slice(0, 63)]),
   );
-}
-
-function stringRecord(value: unknown): Record<string, string> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return {};
-  return Object.fromEntries(
-    Object.entries(value).filter(
-      (entry): entry is [string, string] => typeof entry[1] === 'string',
-    ),
-  );
-}
-
-function stringOption(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
-}
-
-function numberOption(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
-
-function workerEnvironment(env: Record<string, string>): Record<string, string> {
-  return {
-    ...env,
-    HOME: WORKER_HOME,
-    USER: WORKER_USER,
-    LOGNAME: WORKER_USER,
-    PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-  };
-}
-
-function throwIfAborted(signal: AbortSignal): void {
-  if (signal.aborted) throw new Error('Run aborted.');
 }
 
 function toError(value: unknown): Error {

--- a/src/orchestrator/worker/sandbox-utils.test.ts
+++ b/src/orchestrator/worker/sandbox-utils.test.ts
@@ -4,11 +4,20 @@ import { describe, test } from 'node:test';
 import type { SandboxExecResult } from '../../types.js';
 import {
   assertExecSucceeded,
+  buildGitCloneCommand,
+  concatBytes,
   execStderr,
   execStdout,
   normalizeRemotePath,
+  numberOption,
   remoteJoin,
+  renderShellEnvironment,
   shellQuote,
+  streamToBytes,
+  stringOption,
+  stringRecord,
+  throwIfAborted,
+  workerEnvironment,
 } from './sandbox-utils.js';
 
 describe('assertExecSucceeded', () => {
@@ -187,6 +196,194 @@ describe('remoteJoin', () => {
   for (const testCase of cases) {
     test(testCase.name, () => {
       assert.equal(remoteJoin(testCase.root, ...testCase.parts), testCase.want);
+    });
+  }
+});
+
+describe('workerEnvironment', () => {
+  const cases: Array<{ name: string; env: Record<string, string>; want: Record<string, string> }> =
+    [
+      {
+        name: 'When the run carries variables then should keep them under the worker identity',
+        env: { GITHUB_TOKEN: 'gh' },
+        want: {
+          GITHUB_TOKEN: 'gh',
+          HOME: '/home/tenki',
+          USER: 'tenki',
+          LOGNAME: 'tenki',
+          PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        },
+      },
+      {
+        // The worker identity is not the caller's to choose.
+        name: 'When the run tries to set HOME then should override it',
+        env: { HOME: '/root' },
+        want: {
+          HOME: '/home/tenki',
+          USER: 'tenki',
+          LOGNAME: 'tenki',
+          PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        },
+      },
+    ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      assert.deepEqual(workerEnvironment(testCase.env), testCase.want);
+    });
+  }
+});
+
+describe('renderShellEnvironment', () => {
+  const cases: Array<{ name: string; env: Record<string, string>; want: string }> = [
+    {
+      name: 'When a value contains shell syntax then should quote it',
+      env: { SAFE_NAME: "one'two" },
+      want: "export SAFE_NAME='one'\\''two'\n",
+    },
+    {
+      // An unexportable name would render a line the shell refuses to source.
+      name: 'When a name is not a valid identifier then should omit it',
+      env: { 'NOT-SAFE': 'value' },
+      want: '\n',
+    },
+    { name: 'When the environment is empty then should render nothing', env: {}, want: '\n' },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      assert.equal(renderShellEnvironment(testCase.env), testCase.want);
+    });
+  }
+});
+
+describe('buildGitCloneCommand', () => {
+  test('When a clone is built then should pass the token through a helper, never the URL', () => {
+    const command = buildGitCloneCommand('https://github.com/example/repo.git', '/w/repo');
+
+    assert.match(command, /credential\.helper/);
+    assert.match(command, /password=\$GITHUB_TOKEN/);
+    assert.ok(command.includes("'https://github.com/example/repo.git'"), command);
+    assert.ok(command.includes("'/w/repo'"), command);
+  });
+});
+
+describe('throwIfAborted', () => {
+  const cases: Array<{ name: string; aborted: boolean; wantError?: RegExp }> = [
+    { name: 'When the signal is live then should succeed', aborted: false },
+    {
+      name: 'When the signal is aborted then should return error',
+      aborted: true,
+      wantError: /Run aborted/,
+    },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      const controller = new AbortController();
+      if (testCase.aborted) controller.abort();
+
+      const act = () => throwIfAborted(controller.signal);
+      if (testCase.wantError) assert.throws(act, testCase.wantError);
+      else assert.doesNotThrow(act);
+    });
+  }
+});
+
+describe('streamToBytes', () => {
+  const cases: Array<{ name: string; chunks: string[]; want: string }> = [
+    { name: 'When the stream has one chunk then should return it', chunks: ['only'], want: 'only' },
+    {
+      name: 'When the stream has several chunks then should join them in order',
+      chunks: ['a', 'b', 'c'],
+      want: 'abc',
+    },
+    { name: 'When the stream is empty then should return no bytes', chunks: [], want: '' },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of testCase.chunks) controller.enqueue(encoder.encode(chunk));
+          controller.close();
+        },
+      });
+
+      assert.equal(new TextDecoder().decode(await streamToBytes(stream)), testCase.want);
+    });
+  }
+});
+
+describe('concatBytes', () => {
+  const cases: Array<{ name: string; chunks: string[]; want: string }> = [
+    {
+      name: 'When chunks are given then should join them in order',
+      chunks: ['a', 'bc'],
+      want: 'abc',
+    },
+    { name: 'When no chunks are given then should return no bytes', chunks: [], want: '' },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      const encoder = new TextEncoder();
+      const joined = concatBytes(testCase.chunks.map((chunk) => encoder.encode(chunk)));
+
+      assert.equal(new TextDecoder().decode(joined), testCase.want);
+    });
+  }
+});
+
+describe('stringRecord', () => {
+  const cases: Array<{ name: string; value: unknown; want: Record<string, string> }> = [
+    {
+      name: 'When every value is a string then should keep them all',
+      value: { a: 'x' },
+      want: { a: 'x' },
+    },
+    {
+      name: 'When a value is not a string then should drop that entry',
+      value: { a: 'x', b: 2 },
+      want: { a: 'x' },
+    },
+    { name: 'When the value is an array then should return empty', value: ['a'], want: {} },
+    { name: 'When the value is null then should return empty', value: null, want: {} },
+    { name: 'When the value is not an object then should return empty', value: 'a', want: {} },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      assert.deepEqual(stringRecord(testCase.value), testCase.want);
+    });
+  }
+});
+
+describe('stringOption', () => {
+  const cases: Array<{ name: string; value: unknown; want?: string }> = [
+    { name: 'When the value is a string then should trim it', value: '  x  ', want: 'x' },
+    { name: 'When the value is blank then should return undefined', value: '   ' },
+    { name: 'When the value is not a string then should return undefined', value: 7 },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      assert.equal(stringOption(testCase.value), testCase.want);
+    });
+  }
+});
+
+describe('numberOption', () => {
+  const cases: Array<{ name: string; value: unknown; want?: number }> = [
+    { name: 'When the value is a number then should return it', value: 4, want: 4 },
+    { name: 'When the value is not finite then should return undefined', value: Number.NaN },
+    { name: 'When the value is not a number then should return undefined', value: '4' },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      assert.equal(numberOption(testCase.value), testCase.want);
     });
   }
 });

--- a/src/orchestrator/worker/sandbox-utils.ts
+++ b/src/orchestrator/worker/sandbox-utils.ts
@@ -37,3 +37,83 @@ export function remoteJoin(root: string, ...parts: string[]): string {
   // leading slash into '//suffix'.
   return normalizedRoot === '/' ? `/${suffix}` : `${normalizedRoot}/${suffix}`;
 }
+
+// The agent user the prepared worker images ship, and where Codex auth is
+// forwarded to; every provider lands on the same layout so one image serves each.
+export const WORKER_USER = 'tenki';
+export const WORKER_HOME = '/home/tenki';
+
+// workerEnvironment pins the run's environment to the agent user's home, name
+// and PATH, whatever the caller passed for them.
+export function workerEnvironment(env: Record<string, string>): Record<string, string> {
+  return {
+    ...env,
+    HOME: WORKER_HOME,
+    USER: WORKER_USER,
+    LOGNAME: WORKER_USER,
+    PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+  };
+}
+
+// renderShellEnvironment writes the environment as a sourceable script, dropping
+// any name a shell cannot export rather than breaking the whole file.
+export function renderShellEnvironment(env: Record<string, string>): string {
+  return `${Object.entries(env)
+    .filter(([name]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(name))
+    .map(([name, value]) => `export ${name}=${shellQuote(value)}`)
+    .join('\n')}\n`;
+}
+
+// buildGitCloneCommand builds a clone that reads the token from a credential
+// helper, so it never lands in the URL, the process list or .git/config.
+export function buildGitCloneCommand(url: string, directory: string): string {
+  const credentialHelper =
+    '!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f';
+  return `git -c credential.helper=${shellQuote(credentialHelper)} clone ${shellQuote(url)} ${shellQuote(directory)}`;
+}
+
+export function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw new Error('Run aborted.');
+}
+
+export async function streamToBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return concatBytes(chunks);
+}
+
+export function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  const result = new Uint8Array(chunks.reduce((total, chunk) => total + chunk.byteLength, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+export function stringRecord(value: unknown): Record<string, string> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    ),
+  );
+}
+
+export function stringOption(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+export function numberOption(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}


### PR DESCRIPTION
This PR makes the Daytona runner wait for a session command's real exit status instead of reading an unrecorded one as a failure.

The log stream resolves on any websocket close, clean or not, and the exit status is recorded separately, so a socket dropped mid-Codex came back as exit code 1: the run was reported failed, its sandbox deleted, and a finished Codex run thrown away.

It also moves the helpers both providers carried byte-identical copies of into `sandbox-utils.ts`, warns when a repo sizes a sandbox whose CPU and memory come from its snapshot, and puts the smoke-test sentence in `docs/setup.md` back under the block it describes.

`make check` passes. Line coverage is 100% on `sandbox-utils`, `daytona-worker` and `freestyle-worker`, and the two arms `freestyle-worker` never exercised are covered now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012thP9rSa4uZcSui25nbx1W
