### PR TITLE
infra: upgrade pnpm to 12

### DIFF
--- a/.changeset/pnpm-12.md
+++ b/.changeset/pnpm-12.md
@@ -1,0 +1,4 @@
+---
+---
+
+infra: upgrade pnpm to 12

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,7 @@
 # pinned to match Dockerfile.prod and .nvmrc.
 ARG NODE_VERSION=24-bookworm-slim
 # Must match `packageManager` in package.json.
-ARG PNPM_VERSION=11.23.0
+ARG PNPM_VERSION=12.0.0
 
 FROM node:${NODE_VERSION}
 ARG PNPM_VERSION

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -5,7 +5,7 @@
 # here and in .nvmrc together.
 ARG NODE_VERSION=24-bookworm-slim
 # Must match `packageManager` in package.json.
-ARG PNPM_VERSION=11.23.0
+ARG PNPM_VERSION=12.0.0
 
 FROM node:${NODE_VERSION} AS builder
 ARG PNPM_VERSION

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.0",
   "private": true,
   "license": "MIT",
-  "packageManager": "pnpm@11.24.0",
+  "packageManager": "pnpm@12.0.0",
   "type": "module",
   "scripts": {
     "build": "pnpm run build:server && pnpm run build:web",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0:
+    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    optional: true
+
+  pnpm@12.0.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,20 @@
   "vulnerabilityAlerts": {
     "labels": ["security"]
   },
+  "customManagers": [
+    {
+      "description": "The pnpm pin is repeated outside package.json, where the npm manager never sees it; same depName as `packageManager` so both move in one PR.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Dockerfile\\.dev$/",
+        "/^Dockerfile\\.prod$/",
+        "/^tenki-images/recipes/node-repo-example\\.sh$/"
+      ],
+      "matchStrings": ["PNPM_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "pnpm",
+      "datasourceTemplate": "npm"
+    }
+  ],
   "packageRules": [
     {
       "description": "Manage github-actions SHA pins manually; a digest-bump PR would run CI with the new SHA before anyone reviews it.",

--- a/tenki-images/recipes/node-repo-example.sh
+++ b/tenki-images/recipes/node-repo-example.sh
@@ -5,7 +5,7 @@
 # what your repository uses.
 
 # Pin this to your repository's `packageManager` field so the sandbox and CI agree.
-PNPM_VERSION=11.23.0
+PNPM_VERSION=12.0.0
 
 # corepack caches under $HOME, so the version the tenki user gets has to be prepared
 # as the tenki user; the base already enabled the shims as root.


### PR DESCRIPTION
This PR upgrades pnpm to 12.0.0, including the pins that live outside `package.json`.

Renovate's own PR (#50) moves only `package.json` and the lock file, so the `PNPM_VERSION` pins in both Dockerfiles and in the tenki recipe would have stayed on 11.23.0, already a patch behind before this major. The `customManagers` entry added to `renovate.json` keeps them in step from here on, under the same depName as `packageManager` so both move in one PR.

The lock file is regenerated against current `main` rather than copied from #50, whose branch predates 97bd47a and therefore fails `--frozen-lockfile` on lucide-react. The diff is purely additive: the new `packageManagerDependencies` document, with no dependency churn.

#50 should close itself once this lands.

## Testing

`make check` passes under Node 24 and pnpm 12: 2722 tests, 0 failures.

The images could not be built while preparing this, so the Dockerfiles' own sequence was exercised directly instead. `npm i -g pnpm@12.0.0` under npm 11.19.0 yields a working pnpm 12, which is worth stating because pnpm 12's npm package is a stub whose native binary is materialized by an install script that npm 11 now skips by default; it resolves anyway through the `@pnpm/exe.*` optional dependency. `pnpm ci` and `pnpm install --frozen-lockfile --prod` both succeed against the new lock file, and `pnpm store path` still resolves for the cleanup in `Dockerfile.prod`.

Once the pin matches `packageManager` no auto-switch happens, which also drops the roughly 78 MB of pnpm tooling that the version drift was leaving in the runtime layer. `publish-image.yml` on merge is the first real build of these images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mCjmghkjdUMTeufUW36si

---
_Generated by [Claude Code](https://claude.ai/code/session_019mCjmghkjdUMTeufUW36si)_