### PR TITLE
worker: adopt freestyle 0.2.7 VM lifetime options

### DIFF
--- a/.changeset/freestyle-0-2-7.md
+++ b/.changeset/freestyle-0-2-7.md
@@ -1,0 +1,4 @@
+---
+---
+
+worker: adopt the freestyle 0.2.7 VM lifetime options

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@daytona/sdk": "0.207.0",
     "@tenkicloud/sandbox": "1.0.2",
     "dotenv": "17.4.2",
-    "freestyle": "0.2.2",
+    "freestyle": "0.2.7",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: 17.4.2
         version: 17.4.2
       freestyle:
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.7
+        version: 0.2.7
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -1719,8 +1719,8 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
-  freestyle@0.2.2:
-    resolution: {integrity: sha512-EN53Hu58WhaiiXdawlDBBoBzunUL+ONLOnO2H9iF9fUb4+YrJa/aDeANp+HpBATQZc99Bm/SeqMOkagpfG5K8A==}
+  freestyle@0.2.7:
+    resolution: {integrity: sha512-fTISd4+LyrGB1so1HNhtbfUSaqbMue95lu9Pov7xap3WPNC+NLsXATwpsYuy7dJa7pcj/qIum/aXGgUSV+/CPg==}
     hasBin: true
 
   fsevents@2.3.3:
@@ -3848,7 +3848,7 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
-  freestyle@0.2.2:
+  freestyle@0.2.7:
     dependencies:
       dotenv: 17.4.2
       ws: 8.21.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,8 +21,8 @@ minimumReleaseAgeStrict: true
 minimumReleaseAgeExcludePrune: true
 
 # These versions were locked before the cooldown existed and cannot satisfy it retroactively;
-# @tenkicloud/sandbox and freestyle were pinned by hand, the rest came in transitively under
-# vite. Each entry pins the exact version it excuses, so a later release of the same package is
+# @tenkicloud/sandbox was pinned by hand, the rest came in transitively under vite. Each
+# entry pins the exact version it excuses, so a later release of the same package is
 # still gated, and the prune above drops the entry once nothing resolves to it.
 minimumReleaseAgeExclude:
   - '@oxc-project/types@0.147.0'
@@ -43,4 +43,3 @@ minimumReleaseAgeExclude:
   - '@rolldown/binding-win32-arm64-msvc@1.2.6'
   - '@rolldown/binding-win32-x64-msvc@1.2.6'
   - '@tenkicloud/sandbox@1.0.2'
-  - 'freestyle@0.2.2'

--- a/src/orchestrator/worker/freestyle-worker.test.ts
+++ b/src/orchestrator/worker/freestyle-worker.test.ts
@@ -465,7 +465,7 @@ describe('freestyleVmCreateOptions', () => {
       const options = freestyleVmCreateOptions(testCase.input);
 
       testCase.check(options);
-      assert.deepEqual(options.persistence, { type: 'persistent' });
+      assert.equal(options.autoDeleteSeconds, -1);
       assert.equal(options.automaticRestart, true);
       assert.deepEqual(options.firewall, {
         rules: [{ action: 'allow', source: {}, destination: { public: true } }],

--- a/src/orchestrator/worker/freestyle-worker.ts
+++ b/src/orchestrator/worker/freestyle-worker.ts
@@ -306,10 +306,11 @@ export function freestyleVmCreateOptions(options: Record<string, unknown>): Crea
     slug: freestyleSlug(name),
     displayName: name.slice(0, 63),
     ...(image ? { snapshotId: image } : {}),
-    // A run is many calls against one VM, and an ephemeral VM is deleted the moment
-    // it stops, so any transient stop would take the clone with it. The run deletes
-    // the VM itself; the TTL below reclaims it when the orchestrator never gets there.
-    persistence: { type: 'persistent' },
+    // A run is many calls against one VM, and `0` here would make it ephemeral,
+    // deleted the moment it stops, so any transient stop would take the clone with
+    // it. The run deletes the VM itself; the TTL below reclaims it when the
+    // orchestrator never gets there.
+    autoDeleteSeconds: -1,
     automaticRestart: true,
     ttlSeconds: Math.ceil(maxDurationMs / 1_000) + 300,
     metadata: sanitizeMetadata(stringRecord(options.metadata)),


### PR DESCRIPTION
This PR upgrades freestyle to 0.2.7 and moves the Freestyle worker off the `persistence` option the new SDK removed.

0.2.7 drops `VmPersistence` and the `persistence` field entirely; ephemeral versus persistent is now `autoDeleteSeconds`, where `0` deletes the VM the moment it stops and `-1` (or omitting it) means never, or the plan's cap. The SDK posts the options object verbatim to `/v5/vms`, so this is not only a type error: the API no longer takes the old field.

That is the only breaking change that reaches us. The rest of the 0.2.2 to 0.2.7 surface is a sentinel flip from `0` to `-1` on the other lifetime fields (we set only `ttlSeconds`, to a positive value), an additive `tls` create option, and an added `tlsRules` on the create result.

The bump and the adaptation have to land together, which is why this supersedes #47: `autoDeleteSeconds: -1` is undocumented on 0.2.2, and `persistence` fails type-check on 0.2.7.

`make check` is green: 2722 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZjdNyv24usj7nf1DEZngU

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZjdNyv24usj7nf1DEZngU)_