### PR TITLE
infra: gate major updates and unbatch 0.x patch bumps

### DIFF
--- a/.changeset/renovate-major-approval.md
+++ b/.changeset/renovate-major-approval.md
@@ -1,0 +1,4 @@
+---
+---
+
+infra: hold major updates for dashboard approval and give 0.x patches their own PR

--- a/.changeset/renovate-major-approval.md
+++ b/.changeset/renovate-major-approval.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-infra: hold major updates for dashboard approval and give 0.x patches their own PR
+infra: hold major updates for dashboard approval and give 0.x bumps their own PR

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,11 @@
   ],
   "packageRules": [
     {
+      "description": "A major needs a proper read of its changelog, which rarely happens the week it lands. Park it on the dashboard so it stops holding a concurrency slot, and tick it there when someone is ready to do that work.",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
       "description": "Manage github-actions SHA pins manually; a digest-bump PR would run CI with the new SHA before anyone reviews it.",
       "matchManagers": ["github-actions"],
       "enabled": false
@@ -55,6 +60,13 @@
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"],
       "groupName": "dependencies (patch)"
+    },
+    {
+      "description": "A 0.x release makes no compatibility promise, so its patches break like a major does; freestyle 0.2.2 to 0.2.7 dropped a field the worker passed. Each gets its own PR rather than riding in the batch above, where one broken member holds up the safe ones.",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentVersion": "<1.0.0",
+      "groupName": null
     },
     {
       "groupName": "react",

--- a/renovate.json
+++ b/renovate.json
@@ -62,9 +62,9 @@
       "groupName": "dependencies (patch)"
     },
     {
-      "description": "A 0.x release makes no compatibility promise, so its patches break like a major does; freestyle 0.2.2 to 0.2.7 dropped a field the worker passed. Each gets its own PR rather than riding in the batch above, where one broken member holds up the safe ones.",
+      "description": "A 0.x release makes no compatibility promise, so a minor or a patch there breaks like a major does; freestyle 0.2.2 to 0.2.7 dropped a field the worker passed. Each gets its own PR rather than riding in a batch, where one broken member holds up the safe ones.",
       "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "<1.0.0",
       "groupName": null
     },


### PR DESCRIPTION
This PR holds major updates behind dependency dashboard approval and stops 0.x production dependencies riding in a grouped PR.

A major rarely gets its changelog read the week it lands, so it sits open holding one of the five concurrency slots. `dependencyDashboardApproval` parks it on the dashboard instead, and ticking the box there raises the PR when someone is ready to do that review.

The second rule comes out of #47. A 0.x release makes no compatibility promise, so a minor or a patch there breaks like a major does: `freestyle` 0.2.2 to 0.2.7 removed `CreateVmOptions.persistence` and took the whole `dependencies (patch)` group red with it. Giving those their own PR keeps one broken member from holding up the safe ones. It covers minor as well as patch, so the guard still holds if a minor group is added for production dependencies later. Against today's dashboard it splits the group as intended, with `freestyle` on its own and `@tenkicloud/sandbox` and `yaml` still batched.

Security fixes are unaffected. The `vulnerabilityAlerts` defaults already set `dependencyDashboardApproval: false`, `schedule: []`, `minimumReleaseAge: null` and `prConcurrentLimit: 0`, so a major security bump still bypasses the gate, the weekend schedule, the cooldown and the concurrency cap.

## Testing

`renovate-config-validator --strict` from `renovate@44.82.4` passes on the file as a repository config. A negative control with a deliberate `dependencyDashboardApprovel` typo is rejected, so the pass covers option names inside `packageRules`.

`make check` is green: 2722 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZjdNyv24usj7nf1DEZngU