### PR TITLE
infra: keep lock file maintenance rebased and lowest priority

### DIFF
--- a/.changeset/renovate-lockfile-maintenance.md
+++ b/.changeset/renovate-lockfile-maintenance.md
@@ -1,0 +1,4 @@
+---
+---
+
+infra: rebase lock file maintenance on the base branch and create it last

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,14 @@
   "configMigration": true,
   "rebaseWhen": "conflicted",
   "lockFileMaintenance": {
-    "description": "No Renovate age gate here: pnpm enforces the cooldown for lock file refreshes, and it is the only side that sees the transitive versions pnpm picks. Gating here only warned when a release carried no timestamp.",
+    "description": [
+      "No Renovate age gate here: pnpm enforces the cooldown for lock file refreshes, and it is the only side that sees the transitive versions pnpm picks. Gating here only warned when a release carried no timestamp.",
+      "A refresh is only true of the tree it resolved against, so every merge to main leaves this branch describing a package.json that has moved. Rebasing on the base branch regenerates it, which keeps its green check a statement about the merge someone is actually about to make."
+    ],
     "enabled": true,
     "schedule": ["every weekend"],
-    "minimumReleaseAge": null
+    "minimumReleaseAge": null,
+    "rebaseWhen": "behind-base-branch"
   },
   "prConcurrentLimit": 5,
   "minimumReleaseAge": "14 days",
@@ -38,6 +42,11 @@
       "description": "A major needs a proper read of its changelog, which rarely happens the week it lands. Park it on the dashboard so it stops holding a concurrency slot, and tick it there when someone is ready to do that work.",
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "A lock file refresh carries no update anyone is waiting on, so it is created last and takes one of the concurrency slots above only when a real update does not need it.",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "prPriority": -1
     },
     {
       "description": "Manage github-actions SHA pins manually; a digest-bump PR would run CI with the new SHA before anyone reviews it.",


### PR DESCRIPTION
This PR makes Renovate rebase the lock file maintenance branch whenever main moves, and creates it after every other update.

A lock refresh is only true of the tree it resolved against. Every dependency PR that merges underneath it leaves the branch describing a `package.json` that has moved on, and its green check then describes a merge with a base that no longer exists. `rebaseWhen: "behind-base-branch"` regenerates the branch instead, so the lockfile is always resolved against current `package.json` and the check means what it appears to mean. The cost is one CI run per merge to main while the PR is open.

`prPriority: -1` is the other half. A lock refresh carries no update anyone is waiting on, so it should not hold one of the five concurrency slots while a real update queues behind it. Negative priority puts it last.

It goes in a `packageRules` entry rather than in the `lockFileMaintenance` block, because Renovate only accepts `prPriority` inside `packageRules`; the validator rejects the nested form with `"prPriority" can't be used in "lockFileMaintenance"`.

Together these replace the manual alternative of gating lock file maintenance behind dashboard approval, which would have left the staleness in place and made a pure hygiene task wait on someone remembering to tick a box. Transitive security fixes arrive through this PR.

## Testing

`renovate-config-validator --strict` from `renovate@44.82.4` passes on the file as a repository config.

`make check` is green: 2722 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZjdNyv24usj7nf1DEZngU

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZjdNyv24usj7nf1DEZngU)_